### PR TITLE
chore: add H4 indicators to the "System Feature 1" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Describe the requirements associated with any communications functions required 
 This template illustrates organizing the functional requirements for the product by system features, the major services provided by the product. You may prefer to organize this section by use case, mode of operation, user class, object class, functional hierarchy, or combinations of these, whatever makes the most logical sense for your product.
 ### 4.1 System Feature 1
 Don’t really say “System Feature 1.” State the feature name in just a few words.
-4.1.1   Description and Priority
+#### 4.1.1   Description and Priority
  Provide a short description of the feature and indicate whether it is of High, Medium, or Low priority. You could also include specific priority component ratings, such as benefit, penalty, cost, and risk (each rated on a relative scale from a low of 1 to a high of 9).
-4.1.2   Stimulus/Response Sequences
+#### 4.1.2   Stimulus/Response Sequences
  List the sequences of user actions and system responses that stimulate the behavior defined for this feature. These will correspond to the dialog elements associated with use cases.
-4.1.3   Functional Requirements
+#### 4.1.3   Functional Requirements
  Itemize the detailed functional requirements associated with this feature. These are the software capabilities that must be present in order for the user to carry out the services provided by the feature, or to execute the use case. Include how the product should respond to anticipated error conditions or invalid inputs. Requirements should be concise, complete, unambiguous, verifiable, and necessary. Use “TBD” as a placeholder to indicate when necessary information is not yet available.
  
  Each requirement should be uniquely identified with a sequence number or a meaningful tag of some kind.


### PR DESCRIPTION
without an empty line _before_ them, the `4.1.x` level headings end up being rendered as part of the main paragraph for `4.1`. this makes it incredibly difficult to read.

including the H4 level heading indicators before these headings ensures that these subheadings and their paragraphs are rendered clearly.